### PR TITLE
jwt 검증과 메인서버 프록시 기능을 할 게이트웨이 엔드포인트 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "axios": "^1.12.1",
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
     "passport-kakao": "^1.0.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
@@ -42,6 +43,7 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
+    "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       passport:
         specifier: ^0.7.0
         version: 0.7.0
+      passport-jwt:
+        specifier: ^4.0.1
+        version: 4.0.1
       passport-kakao:
         specifier: ^1.0.1
         version: 1.0.1
@@ -69,6 +72,9 @@ importers:
       '@types/node':
         specifier: ^20.3.1
         version: 20.19.13
+      '@types/passport-jwt':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.3
@@ -682,6 +688,15 @@ packages:
 
   '@types/node@20.19.13':
     resolution: {integrity: sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==}
+
+  '@types/passport-jwt@4.0.1':
+    resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
+
+  '@types/passport-strategy@0.2.38':
+    resolution: {integrity: sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==}
+
+  '@types/passport@1.0.17':
+    resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -2251,6 +2266,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  passport-jwt@4.0.1:
+    resolution: {integrity: sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==}
+
   passport-kakao@1.0.1:
     resolution: {integrity: sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==}
 
@@ -3710,6 +3728,20 @@ snapshots:
   '@types/node@20.19.13':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/passport-jwt@4.0.1':
+    dependencies:
+      '@types/jsonwebtoken': 9.0.7
+      '@types/passport-strategy': 0.2.38
+
+  '@types/passport-strategy@0.2.38':
+    dependencies:
+      '@types/express': 4.17.23
+      '@types/passport': 1.0.17
+
+  '@types/passport@1.0.17':
+    dependencies:
+      '@types/express': 4.17.23
 
   '@types/qs@6.14.0': {}
 
@@ -5593,6 +5625,11 @@ snapshots:
       lines-and-columns: 1.2.4
 
   parseurl@1.3.3: {}
+
+  passport-jwt@4.0.1:
+    dependencies:
+      jsonwebtoken: 9.0.2
+      passport-strategy: 1.0.0
 
   passport-kakao@1.0.1:
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { GatewayModule } from './gateway/gateway.module';
 
 @Module({
-  imports: [AuthModule, ConfigModule.forRoot({ isGlobal: true })],
+  imports: [AuthModule, ConfigModule.forRoot({ isGlobal: true }), GatewayModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,10 +5,11 @@ import { PassportModule } from '@nestjs/passport';
 import { KakaoStrategy } from './kakao.strategy';
 import { HttpModule } from '@nestjs/axios';
 import { JwtModule } from '@nestjs/jwt';
+import { JwtStrategy } from './jwt.strategy';
 
 @Module({
   imports: [PassportModule, HttpModule, JwtModule.register({})],
   controllers: [AuthController],
-  providers: [AuthService, KakaoStrategy],
+  providers: [AuthService, KakaoStrategy, JwtStrategy],
 })
 export class AuthModule {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { envVariableKeys } from './const/env.const';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(private readonly configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get<string>(envVariableKeys.accessTokenSecret),
+    });
+  }
+
+  async validate(payload: { sub: number | string }) {
+    // passport-jwt가 토큰 검증을 완료한 후, 유효한 경우에만 validate 메소드를 호출합니다.
+    // 여기서 반환되는 값은 request.user에 담기게 됩니다.
+    return { id: payload.sub };
+  }
+}

--- a/src/gateway/gateway.controller.ts
+++ b/src/gateway/gateway.controller.ts
@@ -1,0 +1,49 @@
+import {
+  All,
+  Controller,
+  HttpException,
+  HttpStatus,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Request, Response } from 'express';
+import { GatewayService } from './gateway.service';
+import { firstValueFrom } from 'rxjs';
+import { AxiosError } from 'axios';
+
+@Controller('api')
+@UseGuards(AuthGuard('jwt'))
+export class GatewayController {
+  constructor(private readonly gatewayService: GatewayService) {}
+
+  @All('*')
+  async proxyRequest(@Req() req: Request, @Res() res: Response) {
+    try {
+      const serviceResponse = await firstValueFrom(
+        await this.gatewayService.proxyRequest(req),
+      );
+
+      res.status(serviceResponse.status);
+      // 응답 헤더를 클라이언트에게 그대로 전달
+      for (const [key, value] of Object.entries(serviceResponse.headers)) {
+        res.setHeader(key, value);
+      }
+
+      // 메인 서버의 응답 스트림을 클라이언트에게 파이핑
+      serviceResponse.data.pipe(res);
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        // 메인 서버에서 오류를 반환한 경우, 해당 상태 코드와 응답을 그대로 전달
+        res.status(error.response.status).json(error.response.data);
+      } else {
+        // 그 외의 오류는 내부 서버 오류로 처리
+        throw new HttpException(
+          'An unexpected error occurred.',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+    }
+  }
+}

--- a/src/gateway/gateway.module.ts
+++ b/src/gateway/gateway.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GatewayController } from './gateway.controller';
+import { HttpModule } from '@nestjs/axios';
+import { GatewayService } from './gateway.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [GatewayController],
+  providers: [GatewayService],
+})
+export class GatewayModule {}

--- a/src/gateway/gateway.service.ts
+++ b/src/gateway/gateway.service.ts
@@ -1,0 +1,51 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class GatewayService {
+  private readonly logger = new Logger(GatewayService.name);
+  private readonly MAIN_SERVER_URL: string;
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    this.MAIN_SERVER_URL = this.configService.get('MAIN_SERVER_URL');
+    if (!this.MAIN_SERVER_URL) {
+      // MAIN_SERVER_URL이 없으면 게이트웨이가 동작할 수 없으므로 에러를 발생시킵니다.
+      throw new Error('MAIN_SERVER_URL is not defined in environment variables.');
+    }
+  }
+
+  async proxyRequest(req: Request) {
+    const { method, body } = req;
+    const userId = (req.user as { id: number | string }).id;
+
+    // 1. 메인 서버로 전달될 최종 URL 생성
+    // 예: /api/posts -> http://main-server/posts
+    const requestUrl = req.originalUrl.replace('/api', '');
+    const targetUrl = `${this.MAIN_SERVER_URL}${requestUrl}`;
+
+    this.logger.log(`Proxying request to: ${targetUrl}`);
+
+    // 2. 원본 요청의 헤더를 복사하고, 필요한 헤더 추가
+    const headers = { ...req.headers };
+    // 호스트 헤더는 목적지 서버의 것으로 자동 변경되므로 삭제합니다.
+    delete headers.host;
+    // 커스텀 헤더에 인증된 사용자 ID 추가
+    headers['X-User-ID'] = String(userId);
+
+    // 3. HttpService(axios)를 사용해 메인 서버로 요청 전송
+    return this.httpService.request({
+      method,
+      url: targetUrl,
+      headers,
+      data: body,
+      // 응답을 스트림 형태로 받기 위해 설정
+      responseType: 'stream',
+    });
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#7

## 📝작업 내용

생성한 jwt 토큰검증과 검증 후 메인서버에 요청할 게이트웨이 엔드포인트를 작성했습니다.

이제 클라이언트 요청에 담긴 access와 refresh 토큰은 인증 게이트웨이 서버에서 인가작업이 되며 작업후 메인서버로 요청을 넘겨줍니다.

기능적으로 작동은 완료되었고, 에러 확인작업을 전체적으로 한뒤

리팩토링 사항으로 타입체크과 구조 변경을 할 예정입니다.

## 💬리뷰 요구사항(선택)

